### PR TITLE
Allows for additional option --save to output the imports to a save file at root

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,15 +1,15 @@
 const config = {
-  root: true,
-  parser: "@typescript-eslint/parser",
-  plugins: ["@typescript-eslint"],
-  env: {
-    node: true,
-  },
-  extends: [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
-    "prettier",
-  ],
+    root: true,
+    parser: '@typescript-eslint/parser',
+    plugins: ['@typescript-eslint'],
+    env: {
+        node: true,
+    },
+    extends: [
+        'eslint:recommended',
+        'plugin:@typescript-eslint/recommended',
+        'prettier',
+    ],
 };
 
 module.exports = config;

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,26 +1,26 @@
-const ESLint = require("eslint").ESLint;
+const ESLint = require('eslint').ESLint;
 
 const removeIgnoredFiles = async (files) => {
-  const eslint = new ESLint();
-  const isIgnored = await Promise.all(
-    files.map((file) => {
-      return eslint.isPathIgnored(file);
-    })
-  );
-  const filteredFiles = files.filter((_, i) => !isIgnored[i]);
-  return filteredFiles.join(" ");
+    const eslint = new ESLint();
+    const isIgnored = await Promise.all(
+        files.map((file) => {
+            return eslint.isPathIgnored(file);
+        })
+    );
+    const filteredFiles = files.filter((_, i) => !isIgnored[i]);
+    return filteredFiles.join(' ');
 };
 
 const config = {
-  "*": [
-    async (files) => {
-      const filesToLint = await removeIgnoredFiles(files);
+    '*': [
+        async (files) => {
+            const filesToLint = await removeIgnoredFiles(files);
 
-      return `yarn run lint --fix --max-warnings=0 ${filesToLint}`;
-    },
-    "yarn run format",
-  ],
-  "src/**/*": () => "yarn run tsc",
+            return `yarn run lint --fix --max-warnings=0 ${filesToLint}`;
+        },
+        'yarn run format',
+    ],
+    'src/**/*': () => 'yarn run tsc',
 };
 
 module.exports = config;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,128 +1,153 @@
-import { normalize, resolve, sep } from "path";
-import { Command } from "commander";
+import fs from 'fs';
+import {normalize, resolve, sep} from 'path';
+import {Command} from 'commander';
+import glob from 'glob';
 
-import glob from "glob";
-
-import Counter from "./count";
-import {
-  filesAsJson,
-  filesAsText,
-  importsAsJson,
-  importsAsText,
-} from "./format";
-import { parsePaths } from "./parse";
-import { sortFiles, sortImports } from "./sort";
+import Counter from './count';
+import {filesAsJson, filesAsText, importsAsJson, importsAsText} from './format';
+import {parsePaths} from './parse';
+import {sortFiles, sortImports} from './sort';
 
 const withCounter = async <Item>(
-  rawRootPath: string,
-  getItems: (rootPath: string, counter: Counter) => Item[],
-  useItems: (items: Item[]) => void
+    rawRootPath: string,
+    getItems: (rootPath: string, counter: Counter) => Item[],
+    useItems: (items: Item[]) => void
 ) => {
-  const normalizedRootPath = normalize(rawRootPath);
+    const normalizedRootPath = normalize(rawRootPath);
 
-  const rootPath =
-    normalizedRootPath[normalizedRootPath.length - 1] === sep
-      ? normalizedRootPath.slice(0, -1)
-      : normalizedRootPath;
+    const rootPath =
+        normalizedRootPath[normalizedRootPath.length - 1] === sep
+            ? normalizedRootPath.slice(0, -1)
+            : normalizedRootPath;
 
-  glob(
-    `${rootPath}/**/*.js{,x}`,
-    {
-      ignore: [`${rootPath}/**/node_modules/**/*`],
-    },
-    async (err, paths) => {
-      if (err != null) {
-        console.error(err);
-        process.exit(1);
-      }
+    glob(
+        `${rootPath}/**/*.js{,x}`,
+        {
+            ignore: [`${rootPath}/**/node_modules/**/*`],
+        },
+        async (err, paths) => {
+            if (err != null) {
+                console.error(err);
+                process.exit(1);
+            }
 
-      if (paths.length === 0) {
-        console.error(
-          `Error: No JS or JSX source files found under path "${rootPath}".`
-        );
-        process.exit(1);
-      }
+            if (paths.length === 0) {
+                console.error(
+                    `Error: No JS or JSX source files found under path "${rootPath}".`
+                );
+                process.exit(1);
+            }
 
-      const resolvedRootPath = resolve(rootPath);
+            const resolvedRootPath = resolve(rootPath);
 
-      const counter = await parsePaths(
-        resolvedRootPath,
-        paths.map((path) => resolve(path))
-      );
+            const counter = await parsePaths(
+                resolvedRootPath,
+                paths.map((path) => resolve(path))
+            );
 
-      const items = getItems(resolvedRootPath, counter);
+            const items = getItems(resolvedRootPath, counter);
 
-      if (items.length === 0) {
-        console.error("No import statements found.");
-        process.exit(1);
-      } else {
-        useItems(items);
-      }
-    }
-  );
+            if (items.length === 0) {
+                console.error('No import statements found.');
+                process.exit(1);
+            } else {
+                useItems(items);
+            }
+        }
+    );
 };
 
-const mostCommon = (rawRootPath: string, options: { json: boolean }) => {
-  return withCounter(
-    rawRootPath,
-    (_, counter) => {
-      return sortImports(counter.listImports());
-    },
-    (items) => {
-      if (options.json) {
-        console.log(importsAsJson(items));
-      } else {
-        importsAsText(items).forEach((line) => console.log(line));
-      }
-    }
-  );
+const mostCommon = (
+    rawRootPath: string,
+    options: {json: boolean; save: boolean}
+) => {
+    return withCounter(
+        rawRootPath,
+        (_, counter) => {
+            return sortImports(counter.listImports());
+        },
+        (items) => {
+            if (options.json) {
+                const toPrint = importsAsJson(items);
+
+                if (options.save) {
+                    fs.writeFileSync(
+                        resolve(process.cwd(), './import-count.json'),
+                        toPrint,
+                        'utf-8'
+                    );
+                    return;
+                }
+
+                console.log(toPrint);
+            } else {
+                importsAsText(items).forEach((line) => console.log(line));
+            }
+        }
+    );
 };
 
-const fewestImports = (rawRootPath: string, options: { json: boolean }) => {
-  return withCounter(
-    rawRootPath,
-    (rootPath, counter) => {
-      return sortFiles(counter.listFiles(rootPath));
-    },
-    (items) => {
-      if (options.json) {
-        console.log(filesAsJson(items));
-      } else {
-        filesAsText(items).forEach((line) => console.log(line));
-      }
-    }
-  );
+const fewestImports = (
+    rawRootPath: string,
+    options: {json: boolean; save: boolean}
+) => {
+    return withCounter(
+        rawRootPath,
+        (rootPath, counter) => {
+            return sortFiles(counter.listFiles(rootPath));
+        },
+        (items) => {
+            if (options.json) {
+                const toPrint = filesAsJson(items);
+
+                if (options.save) {
+                    fs.writeFileSync(
+                        resolve(process.cwd(), './import-count.json'),
+                        toPrint,
+                        'utf-8'
+                    );
+                    return;
+                }
+
+                console.log(toPrint);
+            } else {
+                filesAsText(items).forEach((line) => console.log(line));
+            }
+        }
+    );
 };
 
 export const run = async (version: string) => {
-  const command = new Command("import-count")
-    .version(version)
-    .showHelpAfterError(true)
-    .showSuggestionAfterError(true);
+    const command = new Command('import-count')
+        .version(version)
+        .showHelpAfterError(true)
+        .showSuggestionAfterError(true);
 
-  command
-    .command("most-common")
-    .argument(
-      "<dir>",
-      "absolute or relative path to a directory containing JS and/or JSX source files"
-    )
-    .option("--json", "output JSON instead of human-readable text")
-    .description(
-      "print each unique import found in <dir> along with its number of occurrences, sorted by most frequently occurring"
-    )
-    .action(mostCommon);
+    command
+        .command('most-common')
+        .argument(
+            '<dir>',
+            'absolute or relative path to a directory containing JS and/or JSX source files'
+        )
+        .option('--json', 'output JSON instead of human-readable text')
+        .option('--save', 'saves the output instead of printing to the console')
+        .description(
+            'print each unique import found in <dir> along with its number of occurrences, sorted by most frequently occurring'
+        )
+        .action(mostCommon);
 
-  command
-    .command("fewest-imports")
-    .argument(
-      "<dir>",
-      "absolute or relative path to a directory containing JS and/or JSX source files"
-    )
-    .option("--json", "output JSON instead of human-readable text")
-    .description(
-      "print each file in <dir> with its number of imports, sorted by fewest imports"
-    )
-    .action(fewestImports);
+    command
+        .command('fewest-imports')
+        .argument(
+            '<dir>',
+            'absolute or relative path to a directory containing JS and/or JSX source files'
+        )
+        .option('--json', 'output JSON instead of human-readable text')
+        .option('--save', 'saves the output instead of printing to the console')
+        .description(
+            'print each file in <dir> with its number of imports, sorted by fewest imports'
+        )
+        .action(fewestImports);
 
-  await command.parseAsync();
+    await command.parseAsync();
 };

--- a/src/count.ts
+++ b/src/count.ts
@@ -1,11 +1,11 @@
-import type { Ident, Import } from "./parse";
+import type {Ident, Import} from './parse';
 
 interface Count {
-  count: number;
+    count: number;
 }
 
 interface File {
-  path: string;
+    path: string;
 }
 
 type IdentCount = Ident & Count;
@@ -15,75 +15,75 @@ export type ImportCount = Import & Count;
 export type FileCount = File & Count;
 
 export class Counter {
-  #files: Record<string, number>;
-  #imports: Record<string, Record<string, IdentCount>>;
+    #files: Record<string, number>;
+    #imports: Record<string, Record<string, IdentCount>>;
 
-  constructor() {
-    this.#files = {};
-    this.#imports = {};
-  }
-
-  increment(path: string, { ident, kind, mod }: Import): void {
-    const fileCount = this.#files[path];
-
-    if (fileCount == null) {
-      this.#files[path] = 1;
-    } else {
-      this.#files[path] += 1;
+    constructor() {
+        this.#files = {};
+        this.#imports = {};
     }
 
-    const sourceCounter = this.#imports[mod] ?? (this.#imports[mod] = {});
+    increment(path: string, {ident, kind, mod}: Import): void {
+        const fileCount = this.#files[path];
 
-    const key = ident + "." + kind;
-
-    const identOccurrence = sourceCounter[key];
-
-    if (identOccurrence == null) {
-      sourceCounter[key] = {
-        count: 1,
-        ident,
-        kind,
-      };
-    } else {
-      identOccurrence.count += 1;
-    }
-  }
-
-  listFiles(rootPath: string): FileCount[] {
-    return Object.keys(this.#files).reduce((acc, path) => {
-      const count = this.#files[path];
-
-      if (count != null) {
-        acc.push({
-          path: path.replace(rootPath, "").slice(1),
-          count,
-        });
-      }
-
-      return acc;
-    }, [] as FileCount[]);
-  }
-
-  listImports(): ImportCount[] {
-    return Object.keys(this.#imports).reduce((acc, mod) => {
-      const idents = this.#imports[mod];
-
-      if (idents != null) {
-        for (const identString of Object.keys(idents)) {
-          const identCount = idents[identString];
-
-          if (identCount) {
-            acc.push({
-              ...identCount,
-              mod,
-            });
-          }
+        if (fileCount == null) {
+            this.#files[path] = 1;
+        } else {
+            this.#files[path] += 1;
         }
-      }
 
-      return acc;
-    }, [] as ImportCount[]);
-  }
+        const sourceCounter = this.#imports[mod] ?? (this.#imports[mod] = {});
+
+        const key = ident + '.' + kind;
+
+        const identOccurrence = sourceCounter[key];
+
+        if (identOccurrence == null) {
+            sourceCounter[key] = {
+                count: 1,
+                ident,
+                kind,
+            };
+        } else {
+            identOccurrence.count += 1;
+        }
+    }
+
+    listFiles(rootPath: string): FileCount[] {
+        return Object.keys(this.#files).reduce((acc, path) => {
+            const count = this.#files[path];
+
+            if (count != null) {
+                acc.push({
+                    path: path.replace(rootPath, '').slice(1),
+                    count,
+                });
+            }
+
+            return acc;
+        }, [] as FileCount[]);
+    }
+
+    listImports(): ImportCount[] {
+        return Object.keys(this.#imports).reduce((acc, mod) => {
+            const idents = this.#imports[mod];
+
+            if (idents != null) {
+                for (const identString of Object.keys(idents)) {
+                    const identCount = idents[identString];
+
+                    if (identCount) {
+                        acc.push({
+                            ...identCount,
+                            mod,
+                        });
+                    }
+                }
+            }
+
+            return acc;
+        }, [] as ImportCount[]);
+    }
 }
 
 export default Counter;

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,45 +1,45 @@
-import type { FileCount, ImportCount } from "./count";
+import type {FileCount, ImportCount} from './count';
 
 export const importsAsText = (importCounts: ImportCount[]) => {
-  return importCounts.map((importCount) => {
-    if (importCount.kind === "default") {
-      return `import ${importCount.ident} from "${importCount.mod}": ${importCount.count}`;
-    } else if (importCount.kind === "namespace") {
-      return `import * as ${importCount.ident} from "${importCount.mod}": ${importCount.count}`;
-    } else {
-      return `import { ${importCount.ident} } from "${importCount.mod}": ${importCount.count}`;
-    }
-  });
+    return importCounts.map((importCount) => {
+        if (importCount.kind === 'default') {
+            return `import ${importCount.ident} from "${importCount.mod}": ${importCount.count}`;
+        } else if (importCount.kind === 'namespace') {
+            return `import * as ${importCount.ident} from "${importCount.mod}": ${importCount.count}`;
+        } else {
+            return `import { ${importCount.ident} } from "${importCount.mod}": ${importCount.count}`;
+        }
+    });
 };
 
 export const filesAsText = (fileCounts: FileCount[]) => {
-  return fileCounts.map((fileCount) => {
-    return `${fileCount.path}: ${fileCount.count}`;
-  });
+    return fileCounts.map((fileCount) => {
+        return `${fileCount.path}: ${fileCount.count}`;
+    });
 };
 
 export const importsAsJson = (importCounts: ImportCount[]) => {
-  const json = importCounts.reduce((acc, importCount) => {
-    const imp = {
-      count: importCount.count,
-      ident: importCount.ident,
-      kind: importCount.kind,
-    };
+    const json = importCounts.reduce((acc, importCount) => {
+        const imp = {
+            count: importCount.count,
+            ident: importCount.ident,
+            kind: importCount.kind,
+        };
 
-    const modImports = acc[importCount.mod];
+        const modImports = acc[importCount.mod];
 
-    if (modImports == null) {
-      acc[importCount.mod] = [imp];
-    } else {
-      modImports.push(imp);
-    }
+        if (modImports == null) {
+            acc[importCount.mod] = [imp];
+        } else {
+            modImports.push(imp);
+        }
 
-    return acc;
-  }, {} as { [mod: string]: Omit<ImportCount, "mod">[] });
+        return acc;
+    }, {} as {[mod: string]: Omit<ImportCount, 'mod'>[]});
 
-  return JSON.stringify(json);
+    return JSON.stringify(json);
 };
 
 export const filesAsJson = (fileCounts: FileCount[]) => {
-  return JSON.stringify(fileCounts);
+    return JSON.stringify(fileCounts);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,4 @@
-export { Counter } from "./count";
-export {
-  filesAsJson,
-  filesAsText,
-  importsAsJson,
-  importsAsText,
-} from "./format";
-export { parsePaths } from "./parse";
-export { sortFiles, sortImports } from "./sort";
+export {Counter} from './count';
+export {filesAsJson, filesAsText, importsAsJson, importsAsText} from './format';
+export {parsePaths} from './parse';
+export {sortFiles, sortImports} from './sort';

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -1,19 +1,19 @@
-import type { FileCount, ImportCount } from "./count";
+import type {FileCount, ImportCount} from './count';
 
 export const sortImports = (importCounts: ImportCount[]) => {
-  return importCounts.sort((a, b) => {
-    const aString = `${a.mod}.${a.ident}`;
-    const bString = `${b.mod}.${b.ident}`;
-    if (a.count === b.count) {
-      return aString.localeCompare(bString);
-    }
+    return importCounts.sort((a, b) => {
+        const aString = `${a.mod}.${a.ident}`;
+        const bString = `${b.mod}.${b.ident}`;
+        if (a.count === b.count) {
+            return aString.localeCompare(bString);
+        }
 
-    return b.count - a.count;
-  });
+        return b.count - a.count;
+    });
 };
 
 export const sortFiles = (fileCounts: FileCount[]) => {
-  return fileCounts.sort((a, b) => {
-    return a.count - b.count;
-  });
+    return fileCounts.sort((a, b) => {
+        return a.count - b.count;
+    });
 };


### PR DESCRIPTION
There's no PR template to follow but the gist of the problem is that I would like to use this package to then filter out the noise. To easily do that I want to save the output of this script to a file that I can then use elsewhere